### PR TITLE
Implement interfaces of loading and saving YAML config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
-EXP-*/
+ACTOR-*/
+LEARNER-*/
 
 ### Copied from https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
 # Byte-compiled / optimized / DLL files

--- a/README.md
+++ b/README.md
@@ -9,43 +9,11 @@ export HOROVOD_GPU_OPERATIONS=NCCL
 
 conda env create -f env.yml
 
-# Actor
-python actor.py --env PongNoFrameskip-v4 --num_steps 1e7 --alg dqn --ip 127.0.0.1 --num_replicas 4
+# Run tuned examples saved by YAML files
+python actor.py --config examples/ppo/cartpole_actor.yaml
+python learner.py --config examples/ppo/cartpole_learner.yaml
 
-# Learner
-python learner.py --env PongNoFrameskip-v4 --num_steps 1e7 --alg dqn
-```
-
-## Tuned Examples
-
-### DQN CartPole
-
-```shell script
-python actor.py --env CartPole-v1 --alg dqn --model qmlp --ip 127.0.0.1 --num_steps 5000 --exploration_fraction 0.5 --max_steps_per_update 1 --num_replicas 4
-
+# Run with CLI
+python actor.py --env CartPole-v1 --alg dqn --model qmlp --ip localhost --num_steps 5000 --exploration_fraction 0.5 --max_steps_per_update 1 --num_replicas 4
 python learner.py --env CartPole-v1 --alg dqn --model qmlp --training_start 100 --pool_size 5000 --update_freq 50 --num_steps 20000 --lr 0.0005 --training_freq 1 --batch_size 32
-```
-
-### DQN Pong
-
-```shell script
-python actor.py --env PongNoFrameskip-v4 --alg dqn --model qcnn --ip 127.0.0.1 --num_steps 200000 --exploration_fraction 0.1 --max_steps_per_update 1 --num_replicas 5
-
-python learner.py --env PongNoFrameskip-v4 --alg dqn --model qcnn --training_start 5000 --pool_size 5000 --update_freq 1000 --num_steps 1000000 --lr 0.00005 --training_freq 1 --batch_size 32
-```
-
-### PPO CartPole
-
-```shell script
-python actor.py --env CartPole-v1 --alg ppo --model acmlp --ip 127.0.0.1 --num_steps 200000 --max_steps_per_update 4000 --gamma 0.99 --lam 0.97
-
-python learner.py --env CartPole-v1 --alg ppo --model acmlp --num_steps 200000 --pool_size 4000 --training_freq 1 --batch_size 4000
-```
-
-### PPO Pong
-
-```shell script
-python actor.py --env PongNoFrameskip-v4 --alg ppo --model accnn --ip 127.0.0.1 --num_steps 10000000 --max_steps_per_update 1000 --max_episode_length 0 --gamma 0.99 --lam 0.97
-
-python learner.py --env PongNoFrameskip-v4 --alg ppo --model accnn --num_steps 10000000 --pool_size 1000 --training_freq 1 --epochs 10 --batch_size 1000
 ```

--- a/actor.py
+++ b/actor.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import subprocess
 import time
 from argparse import ArgumentParser
 from itertools import count
@@ -199,6 +200,10 @@ def main():
     parsed_args.log_path = parsed_args.exp_path / 'log'
     parsed_args.ckpt_path.mkdir()
     parsed_args.log_path.mkdir()
+
+    # Record commit hash
+    with open(parsed_args.exp_path / 'hash', 'w') as f:
+        f.write(str(subprocess.run('git rev-parse HEAD'.split(), stdout=subprocess.PIPE).stdout.decode('utf-8')))
 
     # Running status of actors
     actor_status = Array('i', [0] * parsed_args.num_replicas)

--- a/actor.py
+++ b/actor.py
@@ -12,26 +12,27 @@ import numpy as np
 import zmq
 from pyarrow import serialize
 
-from common import init_components, save_yaml_config, create_experiment_dir
+from common import init_components, load_yaml_config, save_yaml_config, create_experiment_dir
 from core.mem_pool import MemPool
 from utils import logger
 from utils.cmdline import parse_cmdline_kwargs
 
 parser = ArgumentParser()
-parser.add_argument('--alg', type=str, help='The RL algorithm', required=True)
-parser.add_argument('--env', type=str, help='The game environment', required=True)
-parser.add_argument('--num_steps', type=float, help='The number of total training steps', required=True)
-parser.add_argument('--ip', type=str, help='IP address of learner server', required=True)
+parser.add_argument('--alg', type=str, default='ppo', help='The RL algorithm')
+parser.add_argument('--env', type=str, default='CartPole-v1', help='The game environment')
+parser.add_argument('--num_steps', type=float, default=2e5, help='The number of total training steps')
+parser.add_argument('--ip', type=str, default='localhost', help='IP address of learner server')
 parser.add_argument('--data_port', type=int, default=5000, help='Learner server port to send training data')
 parser.add_argument('--param_port', type=int, default=5001, help='Learner server port to subscribe model parameters')
 parser.add_argument('--num_replicas', type=int, default=1, help='The number of actors')
-parser.add_argument('--model', type=str, default=None, help='Training model')
-parser.add_argument('--max_steps_per_update', type=int, default=1,
+parser.add_argument('--model', type=str, default='acmlp', help='Training model')
+parser.add_argument('--max_steps_per_update', type=int, default=4000,
                     help='The maximum number of steps between each update')
 parser.add_argument('--exp_path', type=str, default=None,
                     help='Directory to save logging data, model parameters and config file')
 parser.add_argument('--num_saved_ckpt', type=int, default=10, help='Number of recent checkpoint files to be saved')
 parser.add_argument('--max_episode_length', type=int, default=1000, help='Maximum length of trajectory')
+parser.add_argument('--config', type=str, default=None, help='The YAML configuration file')
 
 
 def run_one_agent(index, args, unknown_args, actor_status):
@@ -50,11 +51,11 @@ def run_one_agent(index, args, unknown_args, actor_status):
 
     # Initialize environment and agent instance
     env, agent = init_components(args, unknown_args)
-    save_yaml_config(args.exp_path / 'config.yaml', args, agent)
 
     # Configure logging only in one process
     if index == 0:
         logger.configure(str(args.log_path))
+        save_yaml_config(args.exp_path / 'config.yaml', args, 'actor', agent)
     else:
         logger.configure(str(args.log_path), format_strs=[])
 
@@ -190,32 +191,36 @@ def find_new_weights(current_model_id: int, ckpt_path: Path) -> Tuple[Any, int]:
 
 def main():
     # Parse input parameters
-    parsed_args, unknown_args = parser.parse_known_args()
-    parsed_args.num_steps = int(parsed_args.num_steps)
+    args, unknown_args = parser.parse_known_args()
+    args.num_steps = int(args.num_steps)
     unknown_args = parse_cmdline_kwargs(unknown_args)
 
-    create_experiment_dir(parsed_args, 'ACTOR-')
+    # Load config file
+    load_yaml_config(args, unknown_args, 'actor')
 
-    parsed_args.ckpt_path = parsed_args.exp_path / 'ckpt'
-    parsed_args.log_path = parsed_args.exp_path / 'log'
-    parsed_args.ckpt_path.mkdir()
-    parsed_args.log_path.mkdir()
+    # Create experiment directory
+    create_experiment_dir(args, 'ACTOR-')
+
+    args.ckpt_path = args.exp_path / 'ckpt'
+    args.log_path = args.exp_path / 'log'
+    args.ckpt_path.mkdir()
+    args.log_path.mkdir()
 
     # Record commit hash
-    with open(parsed_args.exp_path / 'hash', 'w') as f:
+    with open(args.exp_path / 'hash', 'w') as f:
         f.write(str(subprocess.run('git rev-parse HEAD'.split(), stdout=subprocess.PIPE).stdout.decode('utf-8')))
 
     # Running status of actors
-    actor_status = Array('i', [0] * parsed_args.num_replicas)
+    actor_status = Array('i', [0] * args.num_replicas)
 
     # Run weights subscriber
-    subscriber = Process(target=run_weights_subscriber, args=(parsed_args, actor_status))
+    subscriber = Process(target=run_weights_subscriber, args=(args, actor_status))
     subscriber.start()
 
-    if parsed_args.num_replicas > 1:
+    if args.num_replicas > 1:
         agents = []
-        for i in range(parsed_args.num_replicas):
-            p = Process(target=run_one_agent, args=(i, parsed_args, unknown_args, actor_status))
+        for i in range(args.num_replicas):
+            p = Process(target=run_one_agent, args=(i, args, unknown_args, actor_status))
             p.start()
             os.system(f'taskset -p -c {i % os.cpu_count()} {p.pid}')  # For CPU affinity
 
@@ -224,7 +229,7 @@ def main():
         for agent in agents:
             agent.join()
     else:
-        run_one_agent(0, parsed_args, unknown_args, actor_status)
+        run_one_agent(0, args, unknown_args, actor_status)
 
     subscriber.join()
 

--- a/agents/dqn/dqn_agent.py
+++ b/agents/dqn/dqn_agent.py
@@ -14,7 +14,7 @@ class DQNAgent(Agent):
     def __init__(self, model_cls, observation_space, action_space, config=None, gamma=0.99, lr=0.001, epochs=1,
                  epsilon=1, epsilon_min=0.01, exploration_fraction=0.1, update_freq=1000, training_start=5000,
                  *args, **kwargs):
-        # Default configurations
+        # Define parameters
         self.gamma = gamma
         self.lr = lr
         self.epochs = epochs

--- a/agents/dqn/dqn_agent_keras.py
+++ b/agents/dqn/dqn_agent_keras.py
@@ -12,7 +12,7 @@ class DQNKerasAgent(Agent):
     def __init__(self, model_cls, observation_space, action_space, config=None, gamma=0.99, lr=0.001, epochs=1,
                  epsilon=1, epsilon_min=0.01, exploration_fraction=0.1, update_freq=1000, training_start=5000,
                  verbose=False, *args, **kwargs):
-        # Default configurations
+        # Define parameters
         self.gamma = gamma
         self.lr = lr
         self.epochs = epochs

--- a/agents/ppo/ppo_agent.py
+++ b/agents/ppo/ppo_agent.py
@@ -17,7 +17,7 @@ class PPOAgent(Agent):
                  vf_lr=1e-3, clip_range=0.2, ent_coef=1e-2, epochs=80, target_kl=0.01, *args, **kwargs):
         assert issubclass(model_cls, TFV1Model)
 
-        # Default configurations
+        # Define parameters
         self.gamma = gamma
         self.lam = lam
         self.pi_lr = pi_lr

--- a/agents/ppo/ppo_agent_keras.py
+++ b/agents/ppo/ppo_agent_keras.py
@@ -18,7 +18,7 @@ class PPOKerasAgent(Agent):
                  buffer_size=0, clip_range=0.2, ent_coef=1e-2, epochs=10, verbose=False, *args, **kwargs):
         assert issubclass(model_cls, TFKerasModel)
 
-        # Default configurations
+        # Define parameters
         self.gamma = gamma
         self.lam = lam
         self.lr = lr

--- a/common.py
+++ b/common.py
@@ -1,4 +1,9 @@
+import datetime
+import time
+from pathlib import Path
 from typing import Tuple
+
+import yaml
 
 from agents import agent_registry
 from core import Agent, Env
@@ -28,3 +33,23 @@ def init_components(args, unknown_args) -> Tuple[Env, Agent]:
                       **unknown_args)  # TODO: Add config interface
 
     return env, agent
+
+
+def save_yaml_config(config_path: Path, args, agent: Agent) -> None:
+    with open(config_path, 'w') as f:
+        args_config = {k: v for k, v in vars(args).items() if not k.endswith('path')}
+        args_config['exp_path'] = str(args.exp_path)
+        yaml.dump(args_config, f, sort_keys=False, indent=4)
+        f.write('\n')
+        yaml.dump(agent.export_config(), f, sort_keys=False, indent=4)
+
+
+def create_experiment_dir(args, prefix: str) -> None:
+    if args.exp_path is None:
+        args.exp_path = prefix + datetime.datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d-%H-%M-%S')
+    args.exp_path = Path(args.exp_path)
+
+    if args.exp_path.exists():
+        raise FileExistsError(f'Experiment directory {str(args.exp_path)!r} already exists')
+
+    args.exp_path.mkdir()

--- a/common.py
+++ b/common.py
@@ -59,15 +59,19 @@ def load_yaml_config(args, unknown_args, role_type: str) -> None:
 
 
 def save_yaml_config(config_path: Path, args, role_type: str, agent: Agent) -> None:
+    class Dumper(yaml.Dumper):
+        def increase_indent(self, flow=False, *_, **__):
+            return super().increase_indent(flow=flow, indentless=False)
+
     if role_type not in {'actor', 'learner'}:
         raise ValueError('Invalid role type')
 
     with open(config_path, 'w') as f:
         args_config = {k: v for k, v in vars(args).items() if
                        not k.endswith('path') and k != 'agent_config' and k != 'config'}
-        yaml.dump({role_type: args_config}, f, sort_keys=False, indent=4)
+        yaml.dump({role_type: args_config}, f, sort_keys=False, Dumper=Dumper)
         f.write('\n')
-        yaml.dump({'agent': agent.export_config()}, f, sort_keys=False, indent=4)
+        yaml.dump({'agent': agent.export_config()}, f, sort_keys=False, Dumper=Dumper)
 
 
 def create_experiment_dir(args, prefix: str) -> None:

--- a/core/agent.py
+++ b/core/agent.py
@@ -118,7 +118,7 @@ class Agent(ABC):
             model_config = self.model_instances[0].export_config()
         else:
             model_config = [x.export_config() for x in self.model_instances]
-        param_dict.update({'model': model_config})
+        param_dict.update({'model_config': model_config})
 
         return param_dict
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Type, Union, Dict, List, Tuple
@@ -14,7 +15,7 @@ class Agent(ABC):
         """
         This method MUST be called between (0.) and (4.) in subclasses for doing initialization works
 
-        0. [IN '__init__' of SUBCLASSES] Define default parameters, model configurations and other related variables
+        0. [IN '__init__' of SUBCLASSES] Define parameters, model configurations and other related variables
         1. If 'config' is not 'None', set specified configuration parameters (which appear after 'config') for agent or
         specified configurations for model
         2. Initialize model instances
@@ -118,7 +119,7 @@ class Agent(ABC):
             model_config = self.model_instances[0].export_config()
         else:
             model_config = [x.export_config() for x in self.model_instances]
-        param_dict.update({'model_config': model_config})
+        param_dict.update({'model': model_config})
 
         return param_dict
 
@@ -127,6 +128,8 @@ class Agent(ABC):
         for key, val in config.items():
             if key in get_config_params(self):
                 self.__dict__[key] = val
+            elif key != 'model':
+                warnings.warn(f"Invalid config item '{key}' ignored", RuntimeWarning)
 
     def predict(self, state: Any, *args, **kwargs) -> Any:
         """Get the action distribution at specific state"""
@@ -145,14 +148,23 @@ class Agent(ABC):
         """Initialize model instances"""
         self.model_instances = []
 
+        def create_model_instance(_c: dict):
+            ret = {}
+            for k, v in _c.items():
+                if k in valid_config:
+                    ret[k] = v
+                else:
+                    warnings.warn(f"Invalid config item '{k}' ignored", RuntimeWarning)
+            self.model_instances.append(self.model_cls(self.observation_space, self.action_space, **ret))
+
         if config is not None and 'model' in config:
             model_config = config['model']
+            valid_config = get_config_params(self.model_cls)
 
             if isinstance(model_config, list):
                 for _, c in enumerate(model_config):
-                    self.model_instances.append(self.model_cls(self.observation_space, self.action_space, **c))
+                    create_model_instance(c)
             elif isinstance(model_config, dict):
-                self.model_instances.append(
-                    self.model_cls(self.observation_space, self.action_space, **model_config))
+                create_model_instance(model_config)
         else:
             self.model_instances.append(self.model_cls(self.observation_space, self.action_space))

--- a/core/agent.py
+++ b/core/agent.py
@@ -112,7 +112,7 @@ class Agent(ABC):
 
     def export_config(self) -> dict:
         """Export dictionary as configurations"""
-        param_dict = {p: str(getattr(self, p)) for p in get_config_params(Agent.__init__)}
+        param_dict = {p: getattr(self, p) for p in get_config_params(self)}
 
         if len(self.model_instances) == 1:
             model_config = self.model_instances[0].export_config()
@@ -125,7 +125,7 @@ class Agent(ABC):
     def load_config(self, config: dict) -> None:
         """Load dictionary as configurations and initialize model instances"""
         for key, val in config.items():
-            if key in get_config_params(Agent.__init__):
+            if key in get_config_params(self):
                 self.__dict__[key] = val
 
     def predict(self, state: Any, *args, **kwargs) -> Any:

--- a/core/model.py
+++ b/core/model.py
@@ -6,7 +6,7 @@ from .utils import get_config_params
 
 
 class Model(ABC):
-    def __init__(self, observation_space: Any, action_space: Any, model_id: str = '0', config: dict = None,
+    def __init__(self, observation_space: Any, action_space: Any, config: dict = None, model_id: str = '0',
                  *args, **kwargs) -> None:
         """
         This method MUST be called after (0.) in subclasses
@@ -59,7 +59,7 @@ class Model(ABC):
 
     def export_config(self) -> dict:
         """Export dictionary as configurations"""
-        config_params = get_config_params(Model.__init__)
+        config_params = get_config_params(self)
 
         return {p: getattr(self, p) for p in config_params}
 

--- a/core/model.py
+++ b/core/model.py
@@ -11,7 +11,7 @@ class Model(ABC):
         """
         This method MUST be called after (0.) in subclasses
 
-        0. [IN '__init__' of SUBCLASSES] Define default parameters, layers, tensors and other related variables
+        0. [IN '__init__' of SUBCLASSES] Define parameters, layers, tensors and other related variables
         1. If 'config' is not 'None', set specified configuration parameters (which appear after 'config')
         2. Build model
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,20 +1,19 @@
 import inspect
-from typing import Callable, List
-
-import core
+from typing import List
 
 
-def get_config_params(init_func: Callable) -> List[str]:
+def get_config_params(obj) -> List[str]:
     """
     Return configurable parameters in 'Agent.__init__' and 'Model.__init__' which appear after 'config'
-    :param init_func: 'Agent.__init__' or 'Model.__init__'
+    :param obj: An instance of 'Agent' or 'Model'
     :return: A list of configurable parameters
     """
+    import core  # Import inside function to avoid cyclic import
 
-    if init_func is not core.Agent.__init__ and init_func is not core.Model.__init__:
+    if not isinstance(obj, core.Agent) and not isinstance(obj, core.Model):
         raise ValueError("Only accepts 'Agent.__init__' or 'Model.__init__'")
 
-    sig = list(inspect.signature(init_func).parameters.keys())
+    sig = list(inspect.signature(obj.__init__).parameters.keys())
 
     config_params = []
     config_part = False
@@ -22,6 +21,8 @@ def get_config_params(init_func: Callable) -> List[str]:
         if param == 'config':
             # Following parameters should be what we want
             config_part = True
+        elif param in {'args', 'kwargs'}:
+            pass
         elif config_part:
             config_params.append(param)
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,18 +2,22 @@ import inspect
 from typing import List
 
 
-def get_config_params(obj) -> List[str]:
+def get_config_params(obj_or_cls) -> List[str]:
     """
     Return configurable parameters in 'Agent.__init__' and 'Model.__init__' which appear after 'config'
-    :param obj: An instance of 'Agent' or 'Model'
+    :param obj_or_cls: An instance of 'Agent' / 'Model' OR their corresponding classes (NOT base classes)
     :return: A list of configurable parameters
     """
     import core  # Import inside function to avoid cyclic import
 
-    if not isinstance(obj, core.Agent) and not isinstance(obj, core.Model):
-        raise ValueError("Only accepts 'Agent.__init__' or 'Model.__init__'")
+    if inspect.isclass(obj_or_cls):
+        if not issubclass(obj_or_cls, core.Agent) and not issubclass(obj_or_cls, core.Model):
+            raise ValueError("Only accepts subclasses of 'Agent' or 'Model'")
+    else:
+        if not isinstance(obj_or_cls, core.Agent) and not isinstance(obj_or_cls, core.Model):
+            raise ValueError("Only accepts instances 'Agent' or 'Model'")
 
-    sig = list(inspect.signature(obj.__init__).parameters.keys())
+    sig = list(inspect.signature(obj_or_cls.__init__).parameters.keys())
 
     config_params = []
     config_part = False

--- a/examples/dqn/cartpole_actor.yaml
+++ b/examples/dqn/cartpole_actor.yaml
@@ -1,0 +1,25 @@
+actor:
+  alg: dqn
+  env: CartPole-v1
+  num_steps: 5000
+  ip: 127.0.0.1
+  data_port: 5000
+  param_port: 5001
+  num_replicas: 4
+  model: qmlp
+  max_steps_per_update: 1
+  num_saved_ckpt: 10
+  max_episode_length: 1000
+
+agent:
+  gamma: 0.99
+  lr: 0.001
+  epochs: 1
+  epsilon: 1
+  epsilon_min: 0.01
+  exploration_fraction: 0.5
+  update_freq: 1000
+  training_start: 5000
+  model:
+    - model_id: policy_model
+    - model_id: target_model

--- a/examples/dqn/cartpole_learner.yaml
+++ b/examples/dqn/cartpole_learner.yaml
@@ -1,0 +1,23 @@
+learner:
+  alg: dqn
+  env: CartPole-v1
+  num_steps: 20000
+  data_port: 5000
+  param_port: 5001
+  model: qmlp
+  pool_size: 5000
+  training_freq: 1
+  batch_size: 32
+
+agent:
+  gamma: 0.99
+  lr: 0.0005
+  epochs: 1
+  epsilon: 1
+  epsilon_min: 0.01
+  exploration_fraction: 0.1
+  update_freq: 50
+  training_start: 100
+  model:
+    - model_id: policy_model
+    - model_id: target_model

--- a/examples/dqn/pong_actor.yaml
+++ b/examples/dqn/pong_actor.yaml
@@ -1,0 +1,25 @@
+actor:
+  alg: dqn
+  env: PongNoFrameskip-v4
+  num_steps: 200000
+  ip: 127.0.0.1
+  data_port: 5000
+  param_port: 5001
+  num_replicas: 5
+  model: qcnn
+  max_steps_per_update: 1
+  num_saved_ckpt: 10
+  max_episode_length: 1000
+
+agent:
+  gamma: 0.99
+  lr: 0.001
+  epochs: 1
+  epsilon: 1
+  epsilon_min: 0.01
+  exploration_fraction: 0.1
+  update_freq: 1000
+  training_start: 5000
+  model:
+    - model_id: policy_model
+    - model_id: target_model

--- a/examples/dqn/pong_learner.yaml
+++ b/examples/dqn/pong_learner.yaml
@@ -1,0 +1,23 @@
+learner:
+  alg: dqn
+  env: PongNoFrameskip-v4
+  num_steps: 1000000
+  data_port: 5000
+  param_port: 5001
+  model: qcnn
+  pool_size: 5000
+  training_freq: 1
+  batch_size: 32
+
+agent:
+  gamma: 0.99
+  lr: 5.0e-05
+  epochs: 1
+  epsilon: 1
+  epsilon_min: 0.01
+  exploration_fraction: 0.1
+  update_freq: 1000
+  training_start: 5000
+  model:
+    - model_id: policy_model
+    - model_id: target_model

--- a/examples/ppo/cartpole_actor.yaml
+++ b/examples/ppo/cartpole_actor.yaml
@@ -1,0 +1,24 @@
+actor:
+    alg: ppo
+    env: CartPole-v1
+    num_steps: 200000
+    ip: localhost
+    data_port: 5000
+    param_port: 5001
+    num_replicas: 1
+    model: acmlp
+    max_steps_per_update: 4000
+    num_saved_ckpt: 10
+    max_episode_length: 1000
+
+agent:
+    gamma: 0.97
+    lam: 0.98
+    pi_lr: 0.0003
+    vf_lr: 0.001
+    clip_range: 0.2
+    ent_coef: 0.01
+    epochs: 80
+    target_kl: 0.01
+    model:
+        model_id: policy_model

--- a/examples/ppo/cartpole_learner.yaml
+++ b/examples/ppo/cartpole_learner.yaml
@@ -1,0 +1,22 @@
+learner:
+    alg: ppo
+    env: CartPole-v1
+    num_steps: 200000
+    data_port: 5000
+    param_port: 5001
+    model: acmlp
+    pool_size: 4000
+    training_freq: 1
+    batch_size: 4000
+
+agent:
+    gamma: 0.97
+    lam: 0.98
+    pi_lr: 0.0003
+    vf_lr: 0.001
+    clip_range: 0.2
+    ent_coef: 0.01
+    epochs: 80
+    target_kl: 0.01
+    model:
+        model_id: policy_model

--- a/examples/ppo/pong_actor.yaml
+++ b/examples/ppo/pong_actor.yaml
@@ -1,19 +1,19 @@
 actor:
   alg: ppo
-  env: CartPole-v1
-  num_steps: 200000
-  ip: localhost
+  env: PongNoFrameskip-v4
+  num_steps: 10000000
+  ip: 127.0.0.1
   data_port: 5000
   param_port: 5001
   num_replicas: 1
-  model: acmlp
-  max_steps_per_update: 4000
+  model: accnn
+  max_steps_per_update: 1000
   num_saved_ckpt: 10
-  max_episode_length: 1000
+  max_episode_length: 0
 
 agent:
-  gamma: 0.97
-  lam: 0.98
+  gamma: 0.99
+  lam: 0.97
   pi_lr: 0.0003
   vf_lr: 0.001
   clip_range: 0.2

--- a/examples/ppo/pong_learner.yaml
+++ b/examples/ppo/pong_learner.yaml
@@ -1,13 +1,13 @@
 learner:
   alg: ppo
-  env: CartPole-v1
-  num_steps: 200000
+  env: PongNoFrameskip-v4
+  num_steps: 10000000
   data_port: 5000
   param_port: 5001
-  model: acmlp
-  pool_size: 4000
+  model: accnn
+  pool_size: 1000
   training_freq: 1
-  batch_size: 4000
+  batch_size: 1000
 
 agent:
   gamma: 0.97
@@ -16,7 +16,7 @@ agent:
   vf_lr: 0.001
   clip_range: 0.2
   ent_coef: 0.01
-  epochs: 80
+  epochs: 10
   target_kl: 0.01
   model:
     model_id: policy_model

--- a/learner.py
+++ b/learner.py
@@ -1,4 +1,5 @@
 import pickle
+import subprocess
 import time
 from argparse import ArgumentParser
 from itertools import count
@@ -54,6 +55,10 @@ def main():
     # Save configuration file
     create_experiment_dir(args, 'LEARNER-')
     save_yaml_config(args.exp_path / 'learner.yaml', args, agent)
+
+    # Record commit hash
+    with open(args.exp_path / 'hash', 'w') as f:
+        f.write(str(subprocess.run('git rev-parse HEAD'.split(), stdout=subprocess.PIPE).stdout.decode('utf-8')))
 
     mem_pool = MemPool(capacity=args.pool_size)
 

--- a/learner.py
+++ b/learner.py
@@ -9,7 +9,7 @@ import zmq
 from pyarrow import deserialize
 from tensorflow.keras.backend import set_session
 
-from common import init_components
+from common import init_components, save_yaml_config, create_experiment_dir
 from core.mem_pool import MemPool
 from utils.cmdline import parse_cmdline_kwargs
 
@@ -33,6 +33,7 @@ parser.add_argument('--model', type=str, default=None, help='Training model')
 parser.add_argument('--pool_size', type=int, default=100, help='The max length of data pool')
 parser.add_argument('--training_freq', type=int, default=100, help='How many steps are between each training')
 parser.add_argument('--batch_size', type=int, default=128, help='The batch size for training')
+parser.add_argument('--exp_path', type=str, default=None, help='Directory to save logging data and config file')
 
 
 def main():
@@ -49,6 +50,10 @@ def main():
     weights_socket.bind(f'tcp://*:{args.param_port}')
 
     env, agent = init_components(args, unknown_args)
+
+    # Save configuration file
+    create_experiment_dir(args, 'LEARNER-')
+    save_yaml_config(args.exp_path / 'learner.yaml', args, agent)
 
     mem_pool = MemPool(capacity=args.pool_size)
 

--- a/models/ac_model.py
+++ b/models/ac_model.py
@@ -11,7 +11,7 @@ __all__ = ['ACModel', 'ACMLPModel', 'ACCNNModel']
 
 
 class ACModel(TFV1Model, ABC):
-    def __init__(self, observation_space, action_space, model_id='0', config=None, *args, **kwargs):
+    def __init__(self, observation_space, action_space, config=None, model_id='0', *args, **kwargs):
         with tf.variable_scope(model_id):
             self.x_ph = utils.placeholder(shape=observation_space)
             self.a_ph = utils.placeholder(dtype=tf.int32)
@@ -22,7 +22,7 @@ class ACModel(TFV1Model, ABC):
         self.logp_pi = None
         self.v = None
 
-        super(ACModel, self).__init__(observation_space, action_space, model_id, config, scope=model_id,
+        super(ACModel, self).__init__(observation_space, action_space, config, model_id, scope=model_id,
                                       *args, **kwargs)
 
     def forward(self, states: Any, *args, **kwargs) -> Any:

--- a/models/ac_model_keras.py
+++ b/models/ac_model_keras.py
@@ -9,7 +9,7 @@ __all__ = ['ACMLPKModel', 'ACCNNKModel']
 
 @model_registry.register('acmlpk')
 class ACMLPKModel(TFKerasModel):
-    def __init__(self, observation_space, action_space, model_id='0', config=None, *args, **kwargs):
+    def __init__(self, observation_space, action_space, config=None, model_id='0', *args, **kwargs):
         self.actor_layers = [
             {'units': 64, 'activation': 'relu'},
             {'units': 64, 'activation': 'relu'},
@@ -22,7 +22,7 @@ class ACMLPKModel(TFKerasModel):
             {'units': 1, 'activation': 'linear'},
         ]
 
-        super(ACMLPKModel, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(ACMLPKModel, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
     def build(self) -> None:
         actor_model = Sequential()
@@ -61,7 +61,7 @@ class ACCNNKModel(TFKerasModel):
             {'units': 1, 'activation': 'linear'},
         ]
 
-        super(ACCNNKModel, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(ACCNNKModel, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
     def build(self) -> None:
         base_model = Sequential()

--- a/models/q_model.py
+++ b/models/q_model.py
@@ -11,14 +11,14 @@ __all__ = ['QModel', 'QMLPModel', 'QCNNModel']
 
 
 class QModel(TFV1Model, ABC):
-    def __init__(self, observation_space, action_space, model_id='0', config=None, *args, **kwargs):
+    def __init__(self, observation_space, action_space, config=None, model_id='0', *args, **kwargs):
         with tf.variable_scope(model_id):
             self.x_ph = utils.placeholder(shape=observation_space)
 
         # Output tensors
         self.values = None
 
-        super(QModel, self).__init__(observation_space, action_space, model_id, config, scope=model_id,
+        super(QModel, self).__init__(observation_space, action_space, config, model_id, scope=model_id,
                                      *args, **kwargs)
 
     def forward(self, states: Any, *args, **kwargs) -> Any:

--- a/models/q_model_keras.py
+++ b/models/q_model_keras.py
@@ -10,7 +10,7 @@ __all__ = ['QMLPKModel', 'QCNNKModel']
 @model_registry.register('qmlpk')
 class QMLPKModel(TFKerasModel):
 
-    def __init__(self, observation_space, action_space, model_id='0', config=None, hidden=None, *args, **kwargs):
+    def __init__(self, observation_space, action_space, config=None, model_id='0', hidden=None, *args, **kwargs):
         # Default configurations
         self.hidden_layers = [
             {'units': 24, 'activation': 'relu'},
@@ -22,7 +22,7 @@ class QMLPKModel(TFKerasModel):
         self.layers += [Dense(**x) for x in self.hidden_layers[1:]]
         self.layers.append(Dense(action_space, activation='linear'))
 
-        super(QMLPKModel, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(QMLPKModel, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
     def build(self) -> None:
         self.model = Sequential()
@@ -50,7 +50,7 @@ class QCNNKModel(TFKerasModel):
         self.flatten = Flatten()
         self.dense_layers = [Dense(**x) for x in self.fc]
 
-        super(QCNNKModel, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(QCNNKModel, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
     def build(self) -> None:
         self.model = Sequential()

--- a/models/tf_keras_model.py
+++ b/models/tf_keras_model.py
@@ -6,9 +6,9 @@ from core import Model
 
 
 class TFKerasModel(Model, ABC):
-    def __init__(self, observation_space: Any, action_space: Any, model_id='0', config=None, *args, **kwargs):
+    def __init__(self, observation_space: Any, action_space: Any, config=None, model_id='0', *args, **kwargs):
         self.model = None
-        super(TFKerasModel, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(TFKerasModel, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
     def set_weights(self, weights, *args, **kwargs) -> None:
         self.model.set_weights(weights)

--- a/models/tf_v1_model.py
+++ b/models/tf_v1_model.py
@@ -9,7 +9,7 @@ from core import Model
 
 
 class TFV1Model(Model, ABC):
-    def __init__(self, observation_space: Any, action_space: Any, model_id='0', config=None, session=None, scope=None,
+    def __init__(self, observation_space: Any, action_space: Any, config=None, model_id='0', session=None, scope=None,
                  *args, **kwargs):
         self.scope = scope
 
@@ -18,7 +18,7 @@ class TFV1Model(Model, ABC):
             session = get_session()
         self.sess = session
 
-        super(TFV1Model, self).__init__(observation_space, action_space, model_id, config, *args, **kwargs)
+        super(TFV1Model, self).__init__(observation_space, action_space, config, model_id, *args, **kwargs)
 
         # Build assignment ops
         self._weight_ph = None


### PR DESCRIPTION
To make it easier for users to reproduce a algorithms with the same setting, loading and saving configurations is necessary.

In this PR, we implement following interfaces for such function:

1. Save YAML files after running each experiement
2. Use `--config` to denote the YAML configuration file, which has a higher priority than the CLI interface.
    - The YAML file is separated to two parts, one for Actor/Learner itself and the other for the specified agent class.
    - The model configuration is part of agent configuration.
    - The unkown keys in YAML files will be ignored. For these configurations to work, set them in CLI interface. (This is reserved and designed for any configuration interfaces that are unreachable in the current version of YAML file, such as settings in `Env`)

An example for PPO agent in CartPole:
```yaml
actor:
    alg: ppo
    env: CartPole-v1
    num_steps: 200000
    ip: localhost
    data_port: 5000
    param_port: 5001
    num_replicas: 1
    model: acmlp
    max_steps_per_update: 4000
    num_saved_ckpt: 10
    max_episode_length: 1000

agent:
    gamma: 0.97
    lam: 0.98
    pi_lr: 0.0003
    vf_lr: 0.001
    clip_range: 0.2
    ent_coef: 0.01
    epochs: 80
    target_kl: 0.01
    model:
        model_id: policy_model
```